### PR TITLE
fix: add prop 'remoteEvents' into dependecies of Scheduler update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aldabil/react-scheduler",
-  "version": "2.5.1",
+  "version": "2.5.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@aldabil/react-scheduler",
-      "version": "2.5.1",
+      "version": "2.5.3",
       "license": "MIT",
       "devDependencies": {
         "@emotion/react": "^11.10.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aldabil/react-scheduler",
-  "version": "2.5.2",
+  "version": "2.5.3",
   "description": "React scheduler component based on Material-UI & date-fns",
   "files": [
     "*"

--- a/src/lib/context/state/State.tsx
+++ b/src/lib/context/state/State.tsx
@@ -25,6 +25,7 @@ const initialState = (initial: Partial<SchedulerProps>): SchedulerState => {
 const AppState = ({ initial, children }: AppProps) => {
   const {
     events,
+    remoteEvents,
     resources,
     resourceViewMode,
     month,
@@ -50,6 +51,7 @@ const AppState = ({ initial, children }: AppProps) => {
     if (state.mounted) {
       updateProps({
         events,
+        remoteEvents,
         selectedDate,
         resources,
         resourceViewMode,
@@ -67,6 +69,7 @@ const AppState = ({ initial, children }: AppProps) => {
     //eslint-disable-next-line
   }, [
     events,
+    remoteEvents,
     selectedDate,
     resources,
     resourceViewMode,

--- a/src/lib/views/Day.tsx
+++ b/src/lib/views/Day.tsx
@@ -82,7 +82,7 @@ const Day = () => {
       triggerLoading(false);
     }
     // eslint-disable-next-line
-  }, [selectedDate]);
+  }, [selectedDate, remoteEvents]);
 
   useEffect(() => {
     if (remoteEvents instanceof Function) {

--- a/src/lib/views/Month.tsx
+++ b/src/lib/views/Month.tsx
@@ -75,7 +75,7 @@ const Month = () => {
       triggerLoading(false);
     }
     // eslint-disable-next-line
-  }, [selectedDate]);
+  }, [selectedDate, remoteEvents]);
 
   useEffect(() => {
     if (remoteEvents instanceof Function) {

--- a/src/lib/views/Week.tsx
+++ b/src/lib/views/Week.tsx
@@ -89,7 +89,7 @@ const Week = () => {
       triggerLoading(false);
     }
     // eslint-disable-next-line
-  }, [selectedDate]);
+  }, [selectedDate, remoteEvents]);
 
   useEffect(() => {
     if (remoteEvents instanceof Function) {


### PR DESCRIPTION
Hello @aldabil21 ,  I think it is a bug the update of 'remoteEvents' can not be fired on SchedulerComponent.

I found prop 'remoteEvents' is out of the dependencies of method 'fetchEvents' in Month/Week/Day views.

In addition to beginTime and EndTime the query included, sometimes I want to let remoteEvents make requests with my extra params, like '/events?start=${beginTime}&end={endTime}&customParam=xxx'. When customParam changes, I want to refetch items from server, but it does not work,  I found the change of 'remoteEvents' do not fire the react updating because of dependencies from  inner method 'fetchEvents' lack of it. 

I made some modifications about it of 'useCallback', it works expectedly.
