### PR TITLE
Add indicator for current time

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aldabil/react-scheduler",
-  "version": "2.5.4",
+  "version": "2.5.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@aldabil/react-scheduler",
-      "version": "2.5.4",
+      "version": "2.5.5",
       "license": "MIT",
       "devDependencies": {
         "@emotion/react": "^11.10.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aldabil/react-scheduler",
-  "version": "2.5.4",
+  "version": "2.5.5",
   "description": "React scheduler component based on Material-UI & date-fns",
   "files": [
     "*"

--- a/src/lib/components/events/CurrentTimeBar.tsx
+++ b/src/lib/components/events/CurrentTimeBar.tsx
@@ -1,6 +1,7 @@
 import { Fragment, useEffect, useState } from "react";
 import { differenceInMinutes, setHours } from "date-fns";
 import { BORDER_HEIGHT } from "../../helpers/constants";
+import { TimeIndicatorBar } from "../../styles/styles";
 
 interface CurrentTimeBarProps {
   today: Date;
@@ -24,38 +25,21 @@ function calculateTop({ today, startHour, step, minuteHeight }: CurrentTimeBarPr
 
 const CurrentTimeBar = (props: CurrentTimeBarProps) => {
   const [top, setTop] = useState(calculateTop(props));
-  const color = props.color || "red";
 
   useEffect(() => {
     const interval = setInterval(() => setTop(calculateTop(props)), 60 * 1000);
     return () => clearInterval(interval);
-  });
+  }, []);
+
+  // Prevent showing bar on top of days/header
+  if (top < 0) return null;
 
   return (
     <Fragment>
-      <div
-        style={{
-          position: "absolute",
-          height: "12px",
-          width: "12px",
-          borderRadius: "50%",
-          background: color,
-          marginLeft: "-6px",
-          marginTop: "-5px",
-          zIndex: 500,
-          top: top,
-        }}
-      />
-      <div
-        style={{
-          borderTop: `solid 2px ${color}`,
-          position: "absolute",
-          left: 0,
-          right: 0,
-          zIndex: 500,
-          top: top,
-        }}
-      />
+      <TimeIndicatorBar style={{ top }}>
+        <div />
+        <div />
+      </TimeIndicatorBar>
     </Fragment>
   );
 };

--- a/src/lib/components/events/CurrentTimeBar.tsx
+++ b/src/lib/components/events/CurrentTimeBar.tsx
@@ -1,0 +1,63 @@
+import { Fragment, useEffect, useState } from "react";
+import { differenceInMinutes, setHours } from "date-fns";
+import { BORDER_HEIGHT } from "../../helpers/constants";
+
+interface CurrentTimeBarProps {
+  today: Date;
+  startHour: number;
+  step: number;
+  minuteHeight: number;
+  color?: string;
+}
+
+function calculateTop({ today, startHour, step, minuteHeight }: CurrentTimeBarProps): number {
+  const now = new Date();
+
+  const minutesFromTop = differenceInMinutes(now, setHours(today, startHour));
+  const topSpace = minutesFromTop * minuteHeight;
+  const slotsFromTop = minutesFromTop / step;
+  const borderFactor = slotsFromTop + BORDER_HEIGHT;
+  const top = topSpace + borderFactor;
+
+  return top;
+}
+
+const CurrentTimeBar = (props: CurrentTimeBarProps) => {
+  const [top, setTop] = useState(calculateTop(props));
+  const color = props.color || "red";
+
+  useEffect(() => {
+    const interval = setInterval(() => setTop(calculateTop(props)), 60 * 1000);
+    return () => clearInterval(interval);
+  });
+
+  return (
+    <Fragment>
+      <div
+        style={{
+          position: "absolute",
+          height: "12px",
+          width: "12px",
+          borderRadius: "50%",
+          background: color,
+          marginLeft: "-6px",
+          marginTop: "-5px",
+          zIndex: 500,
+          top: top,
+        }}
+      />
+      <div
+        style={{
+          borderTop: `solid 2px ${color}`,
+          position: "absolute",
+          left: 0,
+          right: 0,
+          zIndex: 500,
+          top: top,
+        }}
+      />
+    </Fragment>
+  );
+};
+
+export default CurrentTimeBar;

--- a/src/lib/components/events/TodayEvents.tsx
+++ b/src/lib/components/events/TodayEvents.tsx
@@ -1,9 +1,10 @@
 import { ProcessedEvent } from "../../types";
 import EventItem from "./EventItem";
-import { differenceInMinutes, setHours } from "date-fns";
+import { differenceInMinutes, setHours, isToday } from "date-fns";
 import { traversCrossingEvents } from "../../helpers/generals";
 import { BORDER_HEIGHT } from "../../helpers/constants";
 import { Fragment } from "react";
+import CurrentTimeBar from "./CurrentTimeBar";
 
 interface TodayEventsProps {
   todayEvents: ProcessedEvent[];
@@ -25,6 +26,15 @@ const TodayEvents = ({
 
   return (
     <Fragment>
+      {isToday(today) && (
+        <CurrentTimeBar
+          today={today}
+          startHour={startHour}
+          step={step}
+          minuteHeight={minuteHeight}
+        />
+      )}
+
       {todayEvents.map((event) => {
         const height = differenceInMinutes(event.end, event.start) * minuteHeight;
         const minituesFromTop = differenceInMinutes(event.start, setHours(today, startHour));

--- a/src/lib/styles/styles.ts
+++ b/src/lib/styles/styles.ts
@@ -127,3 +127,22 @@ export const EventActions = styled("div")(({ theme }) => ({
     },
   },
 }));
+
+export const TimeIndicatorBar = styled("div")(({ theme }) => ({
+  position: "absolute",
+  zIndex: theme.zIndex.tooltip,
+  width: "100%",
+  display: "flex",
+  "& > div:first-of-type": {
+    height: 12,
+    width: 12,
+    borderRadius: "50%",
+    background: theme.palette.error.light,
+    marginLeft: -6,
+    marginTop: -5,
+  },
+  "& > div:last-of-type": {
+    borderTop: `solid 2px ${theme.palette.error.light}`,
+    width: "100%",
+  },
+}));


### PR DESCRIPTION
Closes #65.

Adds the CurrentTimeBar component and displays it in the TodayEvents component. The CurrentTimeBar updates its position every minute.

Here is a screenshot of what it looks like:

<img width="1031" alt="Screen Shot 2022-11-04 at 3 08 17 PM" src="https://user-images.githubusercontent.com/22841845/200074824-08e988c6-d0ba-490d-8bc9-e4b166e7a80f.png">
