### PR TITLE
Adjust indicator based on timeZone prop

### DIFF
--- a/src/lib/components/events/CurrentTimeBar.tsx
+++ b/src/lib/components/events/CurrentTimeBar.tsx
@@ -1,6 +1,7 @@
 import { Fragment, useEffect, useState } from "react";
 import { differenceInMinutes, setHours } from "date-fns";
 import { BORDER_HEIGHT } from "../../helpers/constants";
+import { getTimeZonedDate } from "../../helpers/generals";
 import { TimeIndicatorBar } from "../../styles/styles";
 
 interface CurrentTimeBarProps {
@@ -8,11 +9,18 @@ interface CurrentTimeBarProps {
   startHour: number;
   step: number;
   minuteHeight: number;
+  timeZone?: string;
   color?: string;
 }
 
-function calculateTop({ today, startHour, step, minuteHeight }: CurrentTimeBarProps): number {
-  const now = new Date();
+function calculateTop({
+  today,
+  startHour,
+  step,
+  minuteHeight,
+  timeZone,
+}: CurrentTimeBarProps): number {
+  const now = getTimeZonedDate(new Date(), timeZone);
 
   const minutesFromTop = differenceInMinutes(now, setHours(today, startHour));
   const topSpace = minutesFromTop * minuteHeight;

--- a/src/lib/components/events/TodayEvents.tsx
+++ b/src/lib/components/events/TodayEvents.tsx
@@ -13,6 +13,7 @@ interface TodayEventsProps {
   step: number;
   minuteHeight: number;
   direction: "rtl" | "ltr";
+  timeZone?: string;
 }
 const TodayEvents = ({
   todayEvents,
@@ -21,6 +22,7 @@ const TodayEvents = ({
   step,
   minuteHeight,
   direction,
+  timeZone,
 }: TodayEventsProps) => {
   const crossingIds: Array<number | string> = [];
 
@@ -32,6 +34,7 @@ const TodayEvents = ({
           startHour={startHour}
           step={step}
           minuteHeight={minuteHeight}
+          timeZone={timeZone}
         />
       )}
 

--- a/src/lib/views/Day.tsx
+++ b/src/lib/views/Day.tsx
@@ -183,6 +183,7 @@ const Day = () => {
                       startHour={startHour}
                       step={step}
                       direction={direction}
+                      timeZone={timeZone}
                     />
                   )}
                   {/* Cell */}

--- a/src/lib/views/Week.tsx
+++ b/src/lib/views/Week.tsx
@@ -230,6 +230,7 @@ const Week = () => {
                         startHour={startHour}
                         step={step}
                         direction={direction}
+                        timeZone={timeZone}
                       />
                     )}
                     <Cell


### PR DESCRIPTION
The indicator currently does not change positions if a different timeZone is passed and instead displays only according to the browser's current time zone. This PR fixes this issue. 