### PR TITLE
Fix bug where time indicator is hidden if day has no events

### DIFF
--- a/src/lib/components/events/TodayEvents.tsx
+++ b/src/lib/components/events/TodayEvents.tsx
@@ -35,7 +35,7 @@ const TodayEvents = ({
           step={step}
           minuteHeight={minuteHeight}
           timeZone={timeZone}
-          zIndex={2 * todayEvents.length}
+          zIndex={2 * todayEvents.length + 1}
         />
       )}
 


### PR DESCRIPTION
I made a mistake in the previous pull request, where the zIndex of the time bar will be set to 0 if there are no events on the current day. This corrects that mistake and ensures that the zIndex will always be at least 1.