### PR TITLE
Add support for MUI palette colors in event props

### DIFF
--- a/src/lib/components/events/EventItem.tsx
+++ b/src/lib/components/events/EventItem.tsx
@@ -7,7 +7,7 @@ import ArrowLeftRoundedIcon from "@mui/icons-material/ArrowLeftRounded";
 import EventNoteRoundedIcon from "@mui/icons-material/EventNoteRounded";
 import ClearRoundedIcon from "@mui/icons-material/ClearRounded";
 import SupervisorAccountRoundedIcon from "@mui/icons-material/SupervisorAccountRounded";
-import { EventItemPapper, PopperInner } from "../../styles/styles";
+import { EventItemPaper, PopperInner } from "../../styles/styles";
 import EventActions from "./Actions";
 import { differenceInDaysOmitTime } from "../../helpers/generals";
 import useStore from "../../hooks/useStore";
@@ -188,11 +188,9 @@ const EventItem = ({ event, multiday, hasPrev, hasNext, showdate = true }: Event
       const custom = eventRenderer({ event, onClick: triggerViewer, ...dragProps });
       if (custom) {
         return (
-          <EventItemPapper
-            key={`${event.start.getTime()}_${event.end.getTime()}_${event.event_id}`}
-          >
+          <EventItemPaper key={`${event.start.getTime()}_${event.end.getTime()}_${event.event_id}`}>
             {custom}
-          </EventItemPapper>
+          </EventItemPaper>
         );
       }
     }
@@ -242,10 +240,12 @@ const EventItem = ({ event, multiday, hasPrev, hasNext, showdate = true }: Event
       );
     }
     return (
-      <EventItemPapper
+      <EventItemPaper
         key={`${event.start.getTime()}_${event.end.getTime()}_${event.event_id}`}
-        color={event.color}
         disabled={event.disabled}
+        sx={{
+          bgcolor: event.disabled ? "#d0d0d0" : event.color || theme.palette.primary.main,
+        }}
       >
         <ButtonBase
           onClick={(e) => {
@@ -262,7 +262,7 @@ const EventItem = ({ event, multiday, hasPrev, hasNext, showdate = true }: Event
             {item}
           </div>
         </ButtonBase>
-      </EventItemPapper>
+      </EventItemPaper>
     );
     // eslint-disable-next-line
   }, [hasPrev, hasNext, event, isDraggable, locale, theme.palette]);

--- a/src/lib/styles/styles.ts
+++ b/src/lib/styles/styles.ts
@@ -130,27 +130,24 @@ export const TableGrid = styled("div")<{
   },
 }));
 
-export const EventItemPapper = styled(Paper)<{ color?: string; disabled?: boolean }>(
-  ({ theme, color, disabled }) => ({
-    width: "99.5%",
+export const EventItemPaper = styled(Paper)<{ disabled?: boolean }>(({ theme, disabled }) => ({
+  width: "99.5%",
+  height: "100%",
+  display: "block",
+  color: disabled ? "#808080" : theme.palette.primary.contrastText,
+  cursor: disabled ? "not-allowed" : "pointer",
+  overflow: "hidden",
+  "& .MuiButtonBase-root": {
+    width: "100%",
     height: "100%",
     display: "block",
-    background: disabled ? "#d0d0d0" : color || theme.palette.primary.main,
-    color: disabled ? "#808080" : theme.palette.primary.contrastText,
-    cursor: disabled ? "not-allowed" : "pointer",
-    overflow: "hidden",
-    "& .MuiButtonBase-root": {
-      width: "100%",
+    textAlign: "left",
+    "& > div": {
       height: "100%",
-      display: "block",
-      textAlign: "left",
-      "& > div": {
-        height: "100%",
-        // padding: "2px 4px",
-      },
+      // padding: "2px 4px",
     },
-  })
-);
+  },
+}));
 
 export const PopperInner = styled("div")(({ theme }) => ({
   maxWidth: "100%",


### PR DESCRIPTION
This PR allows passing a [MUI palette path](https://mui.com/system/getting-started/the-sx-prop/#palette) as the `color` prop on an event.

For example:

```
{
    event_id: 2,
    title: "Event 2",
    start: new Date(new Date(new Date().setHours(10)).setMinutes(0)),
    end: new Date(new Date(new Date().setHours(12)).setMinutes(0)),
    admin_id: 2,
    color: "warning.light",
  }
```

Results in:

<img width="250" alt="Screenshot 2023-09-03 at 4 42 41 PM" src="https://github.com/aldabil21/react-scheduler/assets/22841845/34bfcdf9-31e3-4d14-bf5e-279931f69b23">

This also corrects a typo: `EventItemPapper` -> `EventItemPaper`