### PR TITLE
Fix event items width in month view

### DIFF
--- a/src/lib/components/events/MonthEvents.tsx
+++ b/src/lib/components/events/MonthEvents.tsx
@@ -56,7 +56,10 @@ const MonthEvents = ({
 
       if (toNextWeek) {
         // Rethink it
-        const NotAccurateWeekStart = startOfWeek(event.start);
+        const NotAccurateWeekStart = startOfWeek(event.start, {
+          weekStartsOn: month?.weekStartOn,
+          locale,
+        });
         const closestStart = closestTo(NotAccurateWeekStart, eachWeekStart);
         if (closestStart) {
           eventLength =


### PR DESCRIPTION
Thanks a lot for your project.

I am facing this problem:

When the value of **weekStartOn** property in **month** prop is 1,2 or 3, in **MONTH** view, if you click to add an event on the last (one or two) cell of each row, and select **END DATE** to next days(which is on next row), the width of the event item(class="rs__multi_day") will exceed the view width.

![codesandbox io_s_react-scheduler-demo-standard-v96bd_file=_src_App js](https://github.com/aldabil21/react-scheduler/assets/6228479/2645c314-4faa-4bbf-8299-d0e4fafd99aa)

I think it was this part that caused the problem, I made this modification. However, I am not sure what side effects it may cause, If there are any problems, just ignore it.




