### PR TITLE
Trigger onViewChange when go to day

### DIFF
--- a/src/lib/views/Month.tsx
+++ b/src/lib/views/Month.tsx
@@ -51,6 +51,7 @@ const Month = () => {
     locale,
     hourFormat,
     stickyNavitation,
+    onViewChange,
   } = useStore();
 
   const { weekStartOn, weekDays, startHour, endHour, cellRenderer, headRenderer, disableGoToDay } =
@@ -154,6 +155,9 @@ const Month = () => {
                         e.stopPropagation();
                         if (!disableGoToDay) {
                           handleGotoDay(today);
+                          if (onViewChange && typeof onViewChange === "function") {
+                            onViewChange("day");
+                          }
                         }
                       }}
                     >
@@ -167,7 +171,12 @@ const Month = () => {
                   eachWeekStart={eachWeekStart}
                   eachFirstDayInCalcRow={eachFirstDayInCalcRow}
                   daysList={daysList}
-                  onViewMore={handleGotoDay}
+                  onViewMore={(e) => {
+                    handleGotoDay(e);
+                    if (onViewChange && typeof onViewChange === "function") {
+                      onViewChange("day");
+                    }
+                  }}
                   cellHeight={CELL_HEIGHT}
                 />
               </Fragment>
@@ -198,6 +207,7 @@ const Month = () => {
       theme.palette.secondary.contrastText,
       theme.palette.secondary.main,
       weekDays,
+      onViewChange,
     ]
   );
 


### PR DESCRIPTION
Now onViewChange is only triggered when someone clicks on MonthDateBtn, DayDateBtn or WeekDateBtn in Navigation.
This change causes onViewChange to be triggered also when handleGotoDay is triggered.