### PR TITLE
Support MUI palette colors in event popper

### DIFF
--- a/src/lib/components/events/EventItem.tsx
+++ b/src/lib/components/events/EventItem.tsx
@@ -1,5 +1,5 @@
 import { Fragment, MouseEvent, useMemo, useState } from "react";
-import { Popover, Typography, ButtonBase, useTheme, IconButton } from "@mui/material";
+import { Popover, Typography, ButtonBase, useTheme, IconButton, Box } from "@mui/material";
 import { format } from "date-fns";
 import { ProcessedEvent } from "../../types";
 import ArrowRightRoundedIcon from "@mui/icons-material/ArrowRightRounded";
@@ -94,9 +94,9 @@ const EventItem = ({ event, multiday, hasPrev, hasNext, showdate = true }: Event
 
     return (
       <PopperInner>
-        <div
-          style={{
-            background: event.color || theme.palette.primary.main,
+        <Box
+          sx={{
+            bgcolor: event.color || theme.palette.primary.main,
             color: theme.palette.primary.contrastText,
           }}
         >
@@ -127,7 +127,7 @@ const EventItem = ({ event, multiday, hasPrev, hasNext, showdate = true }: Event
               {event.title}
             </Typography>
           )}
-        </div>
+        </Box>
         <div style={{ padding: "5px 10px" }}>
           <Typography
             style={{ display: "flex", alignItems: "center", gap: 8 }}


### PR DESCRIPTION
Follow up to #249.

```
{
    event_id: 2,
    title: "Event 2",
    start: new Date(new Date(new Date().setHours(10)).setMinutes(0)),
    end: new Date(new Date(new Date().setHours(12)).setMinutes(0)),
    admin_id: 2,
    color: "warning.light",
 }
```

This previously resulted in this:

<img width="936" alt="Screenshot 2023-10-30 at 10 49 40 PM" src="https://github.com/aldabil21/react-scheduler/assets/22841845/56c6e6e8-543d-4d46-9a7f-53e8aab3687a">

Now it results in this:

<img width="793" alt="Screenshot 2023-10-30 at 10 46 30 PM" src="https://github.com/aldabil21/react-scheduler/assets/22841845/f1ce8f94-8168-4de5-b565-1368f8c2679f">
