### PR TITLE
Fix: remove agenda from navigation if agenda = false

### DIFF
--- a/src/lib/components/nav/Navigation.tsx
+++ b/src/lib/components/nav/Navigation.tsx
@@ -37,6 +37,7 @@ const Navigation = () => {
     timeZone,
     agenda,
     toggleAgenda,
+    enableAgenda,
   } = useStore();
   const [anchorEl, setAnchorEl] = useState<Element | null>(null);
   const theme = useTheme();
@@ -110,23 +111,25 @@ const Navigation = () => {
         >
           {translations.navigation.today}
         </Button>
-        {isDesktop ? (
-          <Button
-            color={agenda ? "primary" : "inherit"}
-            onClick={toggleAgenda}
-            aria-label={translations.navigation.agenda}
-          >
-            {translations.navigation.agenda}
-          </Button>
-        ) : (
-          <IconButton
-            color={agenda ? "primary" : "default"}
-            style={{ padding: 5 }}
-            onClick={toggleAgenda}
-          >
-            <ViewAgendaIcon />
-          </IconButton>
-        )}
+        {enableAgenda &&
+          (isDesktop ? (
+            <Button
+              color={agenda ? "primary" : "inherit"}
+              onClick={toggleAgenda}
+              aria-label={translations.navigation.agenda}
+            >
+              {translations.navigation.agenda}
+            </Button>
+          ) : (
+            <IconButton
+              color={agenda ? "primary" : "default"}
+              style={{ padding: 5 }}
+              onClick={toggleAgenda}
+            >
+              <ViewAgendaIcon />
+            </IconButton>
+          ))}
+
         {views.length > 1 &&
           (isDesktop ? (
             views.map((v) => (

--- a/src/lib/store/default.ts
+++ b/src/lib/store/default.ts
@@ -86,7 +86,16 @@ const defaultViews = (props: Partial<SchedulerProps>) => {
 };
 
 export const defaultProps = (props: Partial<SchedulerProps>) => {
-  const { month, week, day, translations, resourceFields, view, ...otherProps } = props;
+  const {
+    month,
+    week,
+    day,
+    translations,
+    resourceFields,
+    view,
+    agenda: enableAgenda = true,
+    ...otherProps
+  } = props;
   const views = defaultViews(props);
   const defaultView = view || "week";
   const initialView = views[defaultView] ? defaultView : getOneView(views);
@@ -119,6 +128,7 @@ export const defaultProps = (props: Partial<SchedulerProps>) => {
         editable: true,
         hourFormat: "12",
         draggable: true,
+        enableAgenda,
       },
       otherProps
     ),

--- a/src/lib/store/types.ts
+++ b/src/lib/store/types.ts
@@ -9,6 +9,7 @@ export interface SchedulerState extends SchedulerProps {
   selectedEvent?: ProcessedEvent;
   selectedResource?: DefaultRecourse["assignee"];
   currentDragged?: ProcessedEvent;
+  enableAgenda?: boolean;
 }
 
 export interface Store extends SchedulerState {


### PR DESCRIPTION
Remove Agenda from nav if `agenda={false}`. 

Closes #309 