### PR TITLE
fix: disableViewer should not prevent events

### DIFF
--- a/src/lib/components/events/EventItem.tsx
+++ b/src/lib/components/events/EventItem.tsx
@@ -133,12 +133,14 @@ const EventItem = ({ event, multiday, hasPrev, hasNext, showdate = true }: Event
           onClick={(e) => {
             e.preventDefault();
             e.stopPropagation();
-            triggerViewer(e);
+            if (!disableViewer) {
+              triggerViewer(e);
+            }
             if (typeof onEventClick === "function") {
               onEventClick(event);
             }
           }}
-          disabled={disableViewer || event.disabled}
+          disabled={event.disabled}
         >
           <div {...dragProps} draggable={isDraggable}>
             {item}


### PR DESCRIPTION
The `disableViewer` property is useful for implementing a custom navigation logic without opening the popover. In order to implement it, the click event should be preserved.