### PR TITLE
Recalculate time bar position on prop change

### DIFF
--- a/src/lib/components/events/CurrentTimeBar.tsx
+++ b/src/lib/components/events/CurrentTimeBar.tsx
@@ -9,7 +9,6 @@ interface CurrentTimeBarProps {
   step: number;
   minuteHeight: number;
   timeZone?: string;
-  color?: string;
   zIndex?: number;
 }
 
@@ -27,12 +26,14 @@ function calculateTop({ startHour, step, minuteHeight, timeZone }: CurrentTimeBa
 
 const CurrentTimeBar = (props: CurrentTimeBarProps) => {
   const [top, setTop] = useState(calculateTop(props));
+  const { startHour, step, minuteHeight, timeZone } = props;
 
   useEffect(() => {
-    const interval = setInterval(() => setTop(calculateTop(props)), 60 * 1000);
+    const calcProps = { startHour, step, minuteHeight, timeZone };
+    setTop(calculateTop(calcProps));
+    const interval = setInterval(() => setTop(calculateTop(calcProps)), 60 * 1000);
     return () => clearInterval(interval);
-    // eslint-disable-next-line
-  }, []);
+  }, [startHour, step, minuteHeight, timeZone]);
 
   // Prevent showing bar on top of days/header
   if (top < 0) return null;


### PR DESCRIPTION
The current time bar position currently does not update if any of its props are changed. This can lead to a confusing state for the user where they change their timezone, and the red bar is now in an incorrect location. This PR fixes that problem.

Additionally, it removes the unused `color` prop from the CurrentTimeBar component.