### PR TITLE
Resource fields can traverse nested object paths

### DIFF
--- a/src/lib/components/common/ResourceHeader.tsx
+++ b/src/lib/components/common/ResourceHeader.tsx
@@ -8,6 +8,7 @@ import {
 } from "@mui/material";
 import { DefaultRecourse } from "../../types";
 import useStore from "../../hooks/useStore";
+import { resolveObjectPath } from "../../utils/objectUtils";
 
 interface ResourceHeaderProps {
   resource: DefaultRecourse;
@@ -16,10 +17,10 @@ const ResourceHeader = ({ resource }: ResourceHeaderProps) => {
   const { resourceHeaderComponent, resourceFields, direction, resourceViewMode } = useStore();
   const theme = useTheme();
 
-  const text = resource[resourceFields.textField];
-  const subtext = resource[resourceFields.subTextField || ""];
-  const avatar = resource[resourceFields.avatarField || ""];
-  const color = resource[resourceFields.colorField || ""];
+  const text = resolveObjectPath(resource, resourceFields.textField);
+  const subtext = resolveObjectPath(resource, resourceFields.subTextField || "");
+  const avatar = resolveObjectPath(resource, resourceFields.avatarField || "");
+  const color = resolveObjectPath(resource, resourceFields.colorField || "");
 
   if (resourceHeaderComponent instanceof Function) {
     return resourceHeaderComponent(resource);
@@ -47,9 +48,11 @@ const ResourceHeader = ({ resource }: ResourceHeaderProps) => {
       }}
       component="div"
     >
-      <ListItemAvatar>
-        <Avatar sx={{ background: color, margin: "auto" }} alt={text} src={avatar} />
-      </ListItemAvatar>
+      {avatar && (
+        <ListItemAvatar>
+          <Avatar sx={{ background: color, margin: "auto" }} alt={text} src={avatar} />
+        </ListItemAvatar>
+      )}
       <ListItemText
         primary={
           <Typography variant="body2" noWrap={resourceViewMode !== "vertical"}>

--- a/src/lib/utils/objectUtils.ts
+++ b/src/lib/utils/objectUtils.ts
@@ -1,0 +1,12 @@
+/**
+ *  Allow for traversing multiple levels of an object when getting a value
+ *
+ * @example To get "Hello World" from this object, use resolveObjectPath({ a: { b: { c: 'Hello World }}}, 'a.b.c')
+ *
+ * @param object The object the path will traverse
+ * @param path The path to the property value you want to get
+ * @param defaultValue (optional) default vlaue if not found
+ * @returns
+ */
+export const resolveObjectPath = (object: any, path: string, defaultValue?: string): any =>
+  path.split(".").reduce((o, p) => (o ? o[p] : defaultValue ?? null), object);


### PR DESCRIPTION
- `resourceFields` can accept object property paths so nested objects can be used
- Avatar will only display if a string is provided

I tested this manually. Here is `App.tsx`
```ts
import { Scheduler } from "./lib";
import { EVENTS, RESOURCES } from "./events";
import { useRef } from "react";
import { SchedulerRef } from "./lib/types";

function App() {
  const calendarRef = useRef<SchedulerRef>(null);

  return (
    <Scheduler
      ref={calendarRef}
      events={EVENTS}
      resources={RESOURCES}
      resourceFields={{
        idField: 'admin_id',
        textField: 'test.name',
        avatarField: ''
      }}
      // events={generateRandomEvents(200)}
    />
  );
}

export default App;
```
and `RESOURCES` array
```ts
export const RESOURCES = [
  {
    admin_id: 1,
    title: "One",
    mobile: "555666777",
    avatar: "",
    color: "#ab2d2d",
    test: {
      name: "Hello"
    }
  },
  {
    admin_id: 2,
    title: "Two is very long name",
    mobile: "555666777",
    avatar: "https://picsum.photos/200/300",
    color: "#58ab2d",
    test: {
      name: "World"
    }
  },
  {
    admin_id: 3,
    title: "Three",
    mobile: "555666777",
    avatar: "https://picsum.photos/200/300",
    color: "#a001a2",
    test: {
      name: "Foo"
    }
  },
  {
    admin_id: 4,
    title: "Four",
    mobile: "555666777",
    avatar: "https://picsum.photos/200/300",
    color: "#08c5bd",
    test: {
      name: "Bar"
    }
  },
];
```
End Result
![Screenshot 2024-04-24 at 4 55 18 PM](https://github.com/aldabil21/react-scheduler/assets/4019874/87b108a7-50f5-40cb-8d2e-22ae6d104528)
