### PR TITLE
Fix rrule bug regarding daylight saving time

### DIFF
--- a/src/events.tsx
+++ b/src/events.tsx
@@ -1,5 +1,6 @@
 import { RRule } from "rrule";
 import { ProcessedEvent } from "./lib/types";
+import { convertDateToRRuleDate } from "./lib/helpers/generals";
 
 export const EVENTS: ProcessedEvent[] = [
   {
@@ -116,8 +117,12 @@ export const EVENTS: ProcessedEvent[] = [
     ),
     recurring: new RRule({
       freq: RRule.WEEKLY,
-      dtstart: new Date(
-        new Date(new Date(new Date().setHours(10)).setMinutes(0)).setDate(new Date().getDate() + 1)
+      dtstart: convertDateToRRuleDate(
+        new Date(
+          new Date(new Date(new Date().setHours(10)).setMinutes(0)).setDate(
+            new Date().getDate() - 20
+          )
+        )
       ),
       until: new Date(
         new Date().setMonth(
@@ -139,7 +144,7 @@ export const EVENTS: ProcessedEvent[] = [
     recurring: new RRule({
       freq: RRule.HOURLY,
       count: 3,
-      dtstart: new Date(new Date(new Date().setHours(14)).setMinutes(15)),
+      dtstart: convertDateToRRuleDate(new Date(new Date(new Date().setHours(14)).setMinutes(15))),
     }),
     color: "#dc4552",
   },


### PR DESCRIPTION
This pr fixes a bug, that originated from a wrong usage of rrule. The documentation states, that rrule should be fed with UTC dates only (see [here](https://github.com/jkbrzt/rrule#important-use-utc-dates)).
E.g. in Germany we have the timezone "Europe/Berlin" which is UTC+2 in summer and UTC+1 in winter (as of october 27th). RRule produced something like:

```
2024-10-25 15:00 [UTC+2]
2024-10-26 15:00 [UTC+2]
2024-10-27 14:00 [UTC+1]
2024-10-28 14:00 [UTC+1]
```

The expected is:

```
2024-10-25 15:00 [UTC+2]
2024-10-26 15:00 [UTC+2]
2024-10-27 15:00 [UTC+1]
2024-10-28 15:00 [UTC+1]
```

This should be fixed with this patch. It was inspired by [this](https://github.com/jkbrzt/rrule/issues/550#issuecomment-1331232622) GitHub issue reply.