### PR TITLE
Fix: Click on More... opens wrong day view, it shoud open clicked day view

### DIFF
--- a/src/lib/components/events/MonthEvents.tsx
+++ b/src/lib/components/events/MonthEvents.tsx
@@ -88,7 +88,7 @@ const MonthEvents = ({
             style={{ top: topSpace, fontSize: 11 }}
             onClick={(e) => {
               e.stopPropagation();
-              onViewMore(event.start);
+              onViewMore(today);
             }}
           >
             {`${Math.abs(events.length - i)} ${translations.moreEvents}`}


### PR DESCRIPTION
Fix: Click on More... from Month view opens wrong day view, it shoud open clicked day view.

To reproduce, create enough events with `event.start < date < event.end` to see More... button on `date` cell. Then click on More...

Currently, it will redirect to `event.start` day. It should redirect to `date` day.

This patch resolves the issue.