### PR TITLE
Background and text colors of current day in month view lack sufficie…

### DIFF
--- a/src/lib/components/month/MonthTable.tsx
+++ b/src/lib/components/month/MonthTable.tsx
@@ -100,13 +100,13 @@ const MonthTable = ({ daysList, resource, eachWeekStart }: Props) => {
                       height: 27,
                       position: "absolute",
                       top: 0,
-                      background: isToday ? theme.palette.secondary.main : "transparent",
+                      background: isToday ? "#1a1a1a" : "transparent",
                       color: isToday ? theme.palette.secondary.contrastText : "",
                       marginBottom: 2,
                     }}
                   >
                     <Typography
-                      color={!isSameMonth(today, monthStart) ? "#ccc" : "textPrimary"}
+                      color={!isSameMonth(today, monthStart) ? "#ccc" : isToday ? "#fff" : "textPrimary"}
                       className={!disableGoToDay ? "rs__hover__op" : ""}
                       onClick={(e) => {
                         e.stopPropagation();


### PR DESCRIPTION
The current colors (black on purple) of current day in month view lack sufficient contrast.

This patch resolves the issue. But It would be great to add options to change background and text colors of current day in month view.