### PR TITLE
fix(#429): missing recurrences for certain timezones

### DIFF
--- a/src/lib/helpers/generals.tsx
+++ b/src/lib/helpers/generals.tsx
@@ -139,7 +139,7 @@ export const getRecurrencesForDate = (event: ProcessedEvent, today: Date, timeZo
   const duration = differenceInMilliseconds(event.end, event.start);
   if (event.recurring) {
     return event.recurring
-      ?.between(today, addDays(today, 1), true)
+      ?.between(addDays(today, -1), addDays(today, 1), true)
       .map((d: Date, index: number) => {
         const start = convertRRuleDateToDate(d);
         return {


### PR DESCRIPTION
This fixes an issue pointed out in #429 where some recurring events will not display. Here is a minimal example you can use to reproduce the problem:

1. Pass the following parameters to the Scheduler component so that you can see all 24 hours of the day on the calendar. (You may have to adjust the timezone to reproduce the bug. My local timezone is Etc/GMT+5, but I am trying to view the calendar in the Etc/GMT+3 timezone)

```
timeZone="Etc/GMT+3"
week={{
  weekDays: [0, 1, 2, 3, 4, 5, 6],
  weekStartOn: 0,
  startHour: 0,
  endHour: 24,
  step: 60,
  navigation: true,
}}
```

2. Add the following event to the calendar:

```
{
    event_id: 11,
    title: "Event 11 (Recurring)",
    subtitle: "This event is recurring daily",
    start: new Date("2025-04-14T00:00:00.000Z"),
    end: new Date("2025-04-14T01:00:00.000Z"),
    disabled: true,
    admin_id: [1, 2, 3, 4],
    recurring: new RRule({
      freq: RRule.DAILY,
      dtstart: convertDateToRRuleDate(new Date("2025-04-14T03:00:00.000Z")),
    }),
  },
```

The issue is that the recurrence gets created, and then `convertEventTimeZone` is called on the event, which pushes the event to the next day. Because the event is now on the next day, the `filterTodayEvents` function ignores it, and the event is never displayed. This fixes the issue by looking for recurrences in the range of [today-1, today+1] instead of [today, today+1]. If the timezoned event then moves into the next day, it is still included on the calendar.