### PR TITLE
fix: Update cell color logic in MonthTable for better constrast text

### DIFF
--- a/src/lib/components/month/MonthTable.tsx
+++ b/src/lib/components/month/MonthTable.tsx
@@ -106,7 +106,13 @@ const MonthTable = ({ daysList, resource, eachWeekStart }: Props) => {
                     }}
                   >
                     <Typography
-                      color={!isSameMonth(today, monthStart) ? "#ccc" : "textPrimary"}
+                      color={
+                        !isSameMonth(today, monthStart)
+                          ? "#ccc"
+                          : isToday
+                            ? theme.palette.secondary.contrastText
+                            : "textPrimary"
+                      }
                       className={!disableGoToDay ? "rs__hover__op" : ""}
                       onClick={(e) => {
                         e.stopPropagation();


### PR DESCRIPTION
Before the fix:
![CleanShot 2025-06-25 at 08 45 46](https://github.com/user-attachments/assets/4c126782-e8a9-495c-bbb3-b14f7a813614)

After the fix:
![CleanShot 2025-06-25 at 08 46 12](https://github.com/user-attachments/assets/3b9c504f-57fc-4865-bbff-643dfc0e64de)
